### PR TITLE
Fixed an issue in Obsidian Registration Entry where group member attribute fields were not being resolved

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrant.partial.ts
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrant.partial.ts
@@ -398,7 +398,7 @@ export default defineComponent({
             <ItemsWithPreAndPostHtml :items="prePostHtmlItems">
                 <template v-for="field in currentFormFields" :key="field.guid" v-slot:[field.guid]>
                     <RegistrantPersonField v-if="field.fieldSource === fieldSources.personField" :field="field" :fieldValues="currentRegistrant.fieldValues" :isKnownFamilyMember="!!currentRegistrant.personGuid" />
-                    <RegistrantAttributeField v-else-if="field.fieldSource === fieldSources.registrantAttribute || field.fieldSource === fieldSources.personAttribute" :field="field" :fieldValues="currentRegistrant.fieldValues" :formFields="currentFormFields" />
+                    <RegistrantAttributeField v-else-if="field.fieldSource === fieldSources.registrantAttribute || field.fieldSource === fieldSources.personAttribute || field.fieldSource === fieldSources.groupMemberAttribute" :field="field" :fieldValues="currentRegistrant.fieldValues" :formFields="currentFormFields" />
                     <Alert alertType="danger" v-else>Could not resolve field source {{field.fieldSource}}</Alert>
                 </template>
             </ItemsWithPreAndPostHtml>


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This fixes an issue where the Obsidian Registration Entry block was unable to display group member attribute fields. This meant that any group member attribute on a registration was not able to be filled out or edited. Instead of showing the field, the block would show an alert that said "Could not resolve field source 2".

This fixes that issue by adding the group member attribute field source to the list of supported field sources.

Screenshot of before this fix:
![GroupMemberFieldsObsidianBlock](https://user-images.githubusercontent.com/110615344/231842554-3e054439-2ba3-4933-a91b-a898db2a258c.png)

Screenshot of after this fix:
![GroupMemberFieldsFixed](https://user-images.githubusercontent.com/110615344/231842656-962cd538-e804-4400-8754-2a08f30db953.png)

Fixes: #4

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
