### PR TITLE
Fixed an issue in Obsidian Registration Entry where Pre/Post HTML was not hidden when filtered

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrant.partial.ts
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrant.partial.ts
@@ -36,8 +36,32 @@ import { PersonBag } from "@Obsidian/ViewModels/Entities/personBag";
 import { ListItemBag } from "@Obsidian/ViewModels/Utility/listItemBag";
 import { useInvokeBlockAction } from "@Obsidian/Utility/block";
 import { ElectronicSignatureValue } from "@Obsidian/ViewModels/Controls/electronicSignatureValue";
+import { FilterExpressionType } from "@Obsidian/Core/Reporting/filterExpressionType";
+import { RegistrationEntryBlockFormFieldRuleViewModel } from "./types";
+import { getFieldType } from "@Obsidian/Utility/fieldTypes";
 
 const store = useStore();
+
+function isRuleMet(rule: RegistrationEntryBlockFormFieldRuleViewModel, fieldValues: Record<Guid, unknown>, formFields: RegistrationEntryBlockFormFieldViewModel[]): boolean {
+    const value = fieldValues[rule.comparedToRegistrationTemplateFormFieldGuid] || "";
+
+    if (typeof value !== "string") {
+        return false;
+    }
+
+    const comparedToFormField = formFields.find(ff => areEqual(ff.guid, rule.comparedToRegistrationTemplateFormFieldGuid));
+    if (!comparedToFormField?.attribute?.fieldTypeGuid) {
+        return false;
+    }
+
+    const fieldType = getFieldType(comparedToFormField.attribute.fieldTypeGuid);
+
+    if (!fieldType) {
+        return false;
+    }
+
+    return fieldType.doesValueMatchFilter(value, rule.comparisonValue, comparedToFormField.attribute.configurationValues ?? {});
+}
 
 export default defineComponent({
     name: "Event.RegistrationEntry.Registrant",
@@ -141,9 +165,48 @@ export default defineComponent({
                 .filter(f => !this.isWaitList || f.showOnWaitList);
         },
 
+        /** The filtered fields to show on the current form augmented to remove pre/post HTML from non-visible fields */
+        currentFormFieldsAugmented(): RegistrationEntryBlockFormFieldViewModel[] {
+            var fields = JSON.parse(JSON.stringify(this.currentFormFields));
+
+            fields.forEach((value, index) => {
+                if (value.fieldSource != this.fieldSources.personField) {
+                    let isVisible = true;
+                    switch (value.visibilityRuleType) {
+                        case FilterExpressionType.GroupAll:
+                            isVisible = value.visibilityRules.every(vr => isRuleMet(vr, this.currentRegistrant.fieldValues, fields));
+                            break;
+
+                        case FilterExpressionType.GroupAllFalse:
+                            isVisible = value.visibilityRules.every(vr => !isRuleMet(vr, this.currentRegistrant.fieldValues, fields));
+                            break;
+
+                        case FilterExpressionType.GroupAny:
+                            isVisible = value.visibilityRules.some(vr => isRuleMet(vr, this.currentRegistrant.fieldValues, fields));
+                            break;
+
+                        case FilterExpressionType.GroupAnyFalse:
+                            isVisible = value.visibilityRules.some(vr => !isRuleMet(vr, this.currentRegistrant.fieldValues, fields));
+                            break;
+
+                        default:
+                            isVisible = true;
+                            break;
+                    }
+
+                    if (isVisible === false) {
+                        value.preHtml = "";
+                        value.postHtml = "";
+                    }
+                }
+            })
+
+            return fields;
+        },
+
         /** The current fields as pre-post items to allow pre-post HTML to be rendered */
         prePostHtmlItems (): ItemWithPreAndPostHtml[] {
-            return this.currentFormFields
+            return this.currentFormFieldsAugmented
                 .map(f => ({
                     preHtml: f.preHtml,
                     postHtml: f.postHtml,


### PR DESCRIPTION
## Notice

**We cannot guarantee that your pull request will be accepted.**  There are many factors involved.  We take into consideration whether or not the Rock system you run is a standard, main-line build.  If it is not, there is a lower chance we will accept your request (since it may impact a part of the system you don't regularly use).  Features that would be used by less than 80% of Rock organizations, or ones that don't match the goals of Rock, are other important factors.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Include screenshots if your pull request either alters existing UI or provides new UI. Arrows and labels are helpful.
-->

This fixes an issue where the Obsidian Registration Entry block was not hiding Pre/Post HTML when its associated attribute was hidden. This is inconsistent with both the C# Registration Entry block and the C# Workflow Entry block. 

This fixes this issue by only sending Pre/Post HTML to the ItemsWithPreAndPostHtml component if the field is visible. If the field is not visible, the Registrant component gives the ItemsWithPreAndPostHtml component empty strings for the Pre/Post HTML.

Screenshot of before this fix (the filtered (hidden) attribute's Pre/Post HTML is shown, even though the attribute is hidden):
![PrePostHtmlObsidianBlock](https://user-images.githubusercontent.com/110615344/231847146-651608ca-7453-4e63-a739-bcf95a765229.png)

Screenshot of after this fix (the filtered (hidden) attribute's Pre/Post HTML is hidden because the attribute is hidden):
![PrePostHtmlFixed](https://user-images.githubusercontent.com/110615344/231847166-a6c36935-0e3e-458b-9541-9723b460a003.png)

Fixes: #5 

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [x] Unit tests pass locally with my changes
- [x] I have added any required [unit tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.UnitTests/README.md) or [integration tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests.Integration/README.md) that prove my fix is effective or that my feature works
- [x] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

## Documentation
<!--
If your change effects the UI or needs to be documented in one of the existing docs http://www.rockrms.com/Learn/Documentation, please provide the brief write-up here.
-->

## Migrations
